### PR TITLE
Fix: Correct import for fetchCurrentUser thunk in App.jsx

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -8,14 +8,14 @@ import LoginPage from '../components/Login/Login';
 import ContactsPage from '../components/ContactsPage/contactsPage';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { fetchCurrentUserThunk } from '../features/authThunks';
+import { fetchCurrentUser } from '../features/authOperations';
 
 function App() {
 
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(fetchCurrentUserThunk());
+    dispatch(fetchCurrentUser());
   }, [dispatch]);
   return (
     <>


### PR DESCRIPTION
I changed the import statement in `src/components/App.jsx` to correctly point to `fetchCurrentUser` from `../features/authOperations` instead of the non-existent `fetchCurrentUserThunk` from `../features/authThunks`.

This resolves an error where the application would fail to find the specified auth thunk during deployment or runtime.